### PR TITLE
Update INSTALL-OSX.md

### DIFF
--- a/INSTALL-OSX.md
+++ b/INSTALL-OSX.md
@@ -26,8 +26,9 @@ brew install cfssl etcd
 
 ### docker
 ```
-brew install docker docker-compose
+brew install docker --cask
 sudo chown -R $(whoami):staff ~/.docker
+open -a Docker
 ```
 
 ### pyenv


### PR DESCRIPTION
1. fix 'docker-compose' v. 'docker compose' incompatibility by installing docker --cask

2. Fix linked issue of `You do not have access to the Docker daemon. Please ensure your user is added to the 'docker' group and try again.` from the installer.sh script and associated `Cannot connect to the Docker daemon at unix:///Users/name/.docker/run/docker.sock. Is the docker daemon running?` docker initialization error by opening docker and accepting EULA and Mac security popups.